### PR TITLE
Improve TOML editor error messages

### DIFF
--- a/src/features/form-definition/__test__/toml-error-format.test.ts
+++ b/src/features/form-definition/__test__/toml-error-format.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { type ZodIssue, ZodIssueCode } from "zod";
+import { resolveTomlLineNumber, formatZodIssue } from "../toml/error-format";
+
+const sampleToml = `title = "My Form"
+actions = "https://example.com"
+
+[[items]]
+type = "short_text"
+title = "Name"
+
+[[items]]
+type = "choice"
+title = "Color"
+choices = ["red", "blue"]
+
+[[items]]
+type = "short_text"
+title = "Age"
+visible_when = 'name = "test"'`;
+
+describe("resolveTomlLineNumber", () => {
+  it("resolves a top-level field", () => {
+    expect(resolveTomlLineNumber(sampleToml, ["title"])).toBe(1);
+  });
+
+  it("resolves actions field", () => {
+    expect(resolveTomlLineNumber(sampleToml, ["actions"])).toBe(2);
+  });
+
+  it("resolves a field in the first item (index 0)", () => {
+    expect(resolveTomlLineNumber(sampleToml, ["items", 0, "title"])).toBe(6);
+  });
+
+  it("resolves a field in the second item (index 1)", () => {
+    expect(resolveTomlLineNumber(sampleToml, ["items", 1, "choices"])).toBe(11);
+  });
+
+  it("resolves a field in the third item (index 2)", () => {
+    expect(resolveTomlLineNumber(sampleToml, ["items", 2, "visible_when"])).toBe(16);
+  });
+
+  it("resolves [[items]] header when path is just items and index", () => {
+    expect(resolveTomlLineNumber(sampleToml, ["items", 1])).toBe(8);
+  });
+
+  it("returns null for a non-existent field", () => {
+    expect(resolveTomlLineNumber(sampleToml, ["items", 0, "nonexistent"])).toBeNull();
+  });
+
+  it("returns null for an out-of-range item index", () => {
+    expect(resolveTomlLineNumber(sampleToml, ["items", 10, "title"])).toBeNull();
+  });
+});
+
+describe("formatZodIssue", () => {
+  const makeIssue = (path: (string | number)[], message: string): ZodIssue =>
+    ({ code: ZodIssueCode.custom, path, message }) as ZodIssue;
+
+  it("formats a top-level field error with line number", () => {
+    const issue = makeIssue(
+      ["title"],
+      "String must contain at least 2 characters",
+    );
+    const result = formatZodIssue(issue, sampleToml);
+    expect(result).toBe(
+      "title (line 1): String must contain at least 2 characters",
+    );
+  });
+
+  it("formats an item field error with ordinal and line number", () => {
+    const result = formatZodIssue(makeIssue(["items", 0, "title"], "Required"), sampleToml);
+    expect(result).toBe("title in 1st item (line 6): Required");
+  });
+
+  it("formats 2nd item correctly", () => {
+    const issue = makeIssue(
+      ["items", 1, "choices"],
+      "Must be an array of unique strings",
+    );
+    const result = formatZodIssue(issue, sampleToml);
+    expect(result).toBe(
+      "choices in 2nd item (line 11): Must be an array of unique strings",
+    );
+  });
+
+  it("formats 3rd item correctly", () => {
+    const result = formatZodIssue(makeIssue(["items", 2, "visible_when"], "Invalid"), sampleToml);
+    expect(result).toBe("visible_when in 3rd item (line 16): Invalid");
+  });
+
+  it("omits line number when it cannot be resolved", () => {
+    const result = formatZodIssue(makeIssue(["items", 10, "title"], "Required"), sampleToml);
+    expect(result).toBe("title in 11th item: Required");
+  });
+
+  it("uses ordinal 4th for index 3", () => {
+    const result = formatZodIssue(makeIssue(["items", 3, "title"], "Required"), sampleToml);
+    expect(result).toMatch(/4th item/);
+  });
+});

--- a/src/features/form-definition/__test__/visible-when-schema.test.ts
+++ b/src/features/form-definition/__test__/visible-when-schema.test.ts
@@ -47,16 +47,18 @@ describe("visible_when schema field", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       const messages = result.error.issues.map(i => i.message);
-      expect(messages).toContain("Invalid visible_when syntax");
+      expect(messages.some(m => m.startsWith("Invalid visible_when:"))).toBe(true);
     }
   });
 
-  it("rejects invalid visible_when syntax", () => {
+  it("rejects invalid visible_when syntax with descriptive message", () => {
     const result = safeParseFormDefinition(makeFormDef({ visible_when: "{{{invalid" }));
     expect(result.success).toBe(false);
     if (!result.success) {
       const messages = result.error.issues.map(i => i.message);
-      expect(messages).toContain("Invalid visible_when syntax");
+      const msg = messages.find(m => m.startsWith("Invalid visible_when:"));
+      expect(msg).toBeDefined();
+      expect(msg).toMatch(/expected .+ at position \d+/);
     }
   });
 

--- a/src/features/form-definition/schema.ts
+++ b/src/features/form-definition/schema.ts
@@ -92,22 +92,24 @@ const actions = z
 const visibleWhen = z
   .string()
   .optional()
-  .refine(
-    val => val === undefined || (val.length > 0 && safeParseSource(val).ok),
-    val => {
-      if (val === undefined || val.length === 0) {
-        return { message: "Invalid visible_when: expected non-empty string" };
-      }
-      const result = safeParseSource(val);
-      if (!result.ok) {
-        return {
-          message: `Invalid visible_when: expected ${result.expect}`
-            + ` at position ${result.pos}: "${val}"`,
-        };
-      }
-      return { message: "Invalid visible_when syntax" };
-    },
-  );
+  .superRefine((val, ctx) => {
+    if (val === undefined) return;
+    if (val.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Invalid visible_when: expected non-empty string",
+      });
+      return;
+    }
+    const result = safeParseSource(val);
+    if (!result.ok) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Invalid visible_when: expected ${result.expect}`
+          + ` at position ${result.pos}: "${val}"`,
+      });
+    }
+  });
 
 const basicFormItem = z.object({
   title: z.string().default(`Set title here`),

--- a/src/features/form-definition/schema.ts
+++ b/src/features/form-definition/schema.ts
@@ -92,9 +92,22 @@ const actions = z
 const visibleWhen = z
   .string()
   .optional()
-  .refine(val => val === undefined || (val.length > 0 && safeParseSource(val).ok), {
-    message: "Invalid visible_when syntax",
-  });
+  .refine(
+    val => val === undefined || (val.length > 0 && safeParseSource(val).ok),
+    val => {
+      if (val === undefined || val.length === 0) {
+        return { message: "Invalid visible_when: expected non-empty string" };
+      }
+      const result = safeParseSource(val);
+      if (!result.ok) {
+        return {
+          message: `Invalid visible_when: expected ${result.expect}`
+            + ` at position ${result.pos}: "${val}"`,
+        };
+      }
+      return { message: "Invalid visible_when syntax" };
+    },
+  );
 
 const basicFormItem = z.object({
   title: z.string().default(`Set title here`),

--- a/src/features/form-definition/store.ts
+++ b/src/features/form-definition/store.ts
@@ -1,3 +1,4 @@
+import { type ZodIssue } from "zod";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { FormDefinition, safeParseFormDefinition as safeParseFormDefinition } from "./schema";
@@ -5,7 +6,7 @@ import { FormDefinitionForEdit } from "./server/types";
 
 interface FormDefinitionStore {
   source: object | null;
-  error: string;
+  error: ZodIssue[];
   setSource: (source: object | null) => void;
   formDefinition: FormDefinition | null;
 }
@@ -15,12 +16,12 @@ const useFormDefinition = create<FormDefinitionStore>()(
     const setSource = (source: object | null) => {
       const res = safeParseFormDefinition(source);
       if (res.success) {
-        set({ formDefinition: res.data, error: "" });
+        set({ formDefinition: res.data, error: [] });
       } else {
-        set({ error: res.error.message });
+        set({ error: res.error.issues });
       }
     };
-    return { source: null, setSource, formDefinition: null, error: "" };
+    return { source: null, setSource, formDefinition: null, error: [] };
   }),
 );
 

--- a/src/features/form-definition/toml/edit-by-toml.tsx
+++ b/src/features/form-definition/toml/edit-by-toml.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { FormEvent, useEffect, useState, useTransition } from "react";
 import { getEditUrl, getViewUrl } from "@/common/url";
-import { ErrorDisplay, useErrorMessage } from "./error-display";
+import { ErrorDisplay, useHasError } from "./error-display";
 import sampleTomlDefinition from "./sample.toml";
 import { initTomlText, useTomlText, resetTomlText } from "./store";
 import { ParamObject } from "../../../common/flatten-object";
@@ -86,7 +86,7 @@ function EditConfig(props: EditConfigProps) {
   const { formDefinitionForEdit } = useFormDefinitionForEdit();
   useInitTomlStore(formDefinitionForEdit);
   const formDefinition = useFormDefinition(s => s.formDefinition);
-  const error = useErrorMessage();
+  const hasError = useHasError();
   const handleOnSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (formDefinition) {
@@ -131,7 +131,7 @@ function EditConfig(props: EditConfigProps) {
         )}
         <button
           className="btn"
-          disabled={!!error && formDefinition !== null && !isPending}
+          disabled={hasError && formDefinition !== null && !isPending}
           type="submit"
         >
           {isPending ? (

--- a/src/features/form-definition/toml/error-display.tsx
+++ b/src/features/form-definition/toml/error-display.tsx
@@ -1,40 +1,50 @@
-import { useTomlDerivedJson } from "./store";
+import { formatZodIssue } from "./error-format";
+import { useTomlDerivedJson, useTomlText } from "./store";
 import { useFormDefinition } from "../store";
 
-export function useErrorMessage() {
-  const { error: syntaxError } = useTomlDerivedJson(s => ({ error: s.error }));
-  const schemaError = useFormDefinition(s => s.error);
-  return (
-    (syntaxError ? "SyntaxError: " + syntaxError : "") ||
-    (schemaError ? "SchemaError: " + schemaError : "")
-  );
+export function useHasError() {
+  const syntaxError = useTomlDerivedJson(s => s.error);
+  const schemaErrors = useFormDefinition(s => s.error);
+  return !!syntaxError || schemaErrors.length > 0;
 }
 
 export function ErrorDisplay() {
-  const error = useErrorMessage();
+  const { error: syntaxError } = useTomlDerivedJson(s => ({ error: s.error }));
+  const schemaErrors = useFormDefinition(s => s.error);
+  const tomlText = useTomlText(s => s.getToml());
+
+  const hasSyntaxError = !!syntaxError;
+  const hasSchemaErrors = schemaErrors.length > 0;
+
+  if (!hasSyntaxError && !hasSchemaErrors) return null;
+
   return (
-    <>
-      {error && (
-        <div
-          className="alert alert-error shadow-lg 
+    <div
+      className="alert alert-error shadow-lg
         m-2 w-[calc(100%-0.5rem)] max-h-32 overflow-auto"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="stroke-current shrink-0 h-6 w-6"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
-          {error}
-        </div>
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="stroke-current shrink-0 h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+      {hasSyntaxError ? (
+        <span>{"SyntaxError: " + syntaxError}</span>
+      ) : (
+        <ul className="list-disc list-inside">
+          {schemaErrors.map((issue, i) => (
+            <li key={i}>{formatZodIssue(issue, tomlText)}</li>
+          ))}
+        </ul>
       )}
-    </>
+    </div>
   );
 }

--- a/src/features/form-definition/toml/error-display.tsx
+++ b/src/features/form-definition/toml/error-display.tsx
@@ -9,7 +9,7 @@ export function useHasError() {
 }
 
 export function ErrorDisplay() {
-  const { error: syntaxError } = useTomlDerivedJson(s => ({ error: s.error }));
+  const syntaxError = useTomlDerivedJson(s => s.error);
   const schemaErrors = useFormDefinition(s => s.error);
   const tomlText = useTomlText(s => s.getToml());
 

--- a/src/features/form-definition/toml/error-format.ts
+++ b/src/features/form-definition/toml/error-format.ts
@@ -64,6 +64,8 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// Teen numbers (11, 12, 13) work correctly: (v - 20) % 10 yields a negative
+// index, which returns undefined from s[], so it falls through to s[0] ("th").
 function ordinal(n: number): string {
   const s = ["th", "st", "nd", "rd"];
   const v = n % 100;

--- a/src/features/form-definition/toml/error-format.ts
+++ b/src/features/form-definition/toml/error-format.ts
@@ -1,0 +1,96 @@
+import { type ZodIssue } from "zod";
+
+/**
+ * Resolve a Zod path to a 1-based line number in TOML text.
+ */
+export function resolveTomlLineNumber(
+  tomlText: string,
+  zodPath: (string | number)[],
+): number | null {
+  const lines = tomlText.split("\n");
+
+  // Top-level field (e.g. ["title"])
+  if (zodPath.length >= 1 && typeof zodPath[0] === "string" && zodPath[0] !== "items") {
+    const fieldName = zodPath[0];
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].match(new RegExp(`^\\s*${escapeRegex(fieldName)}\\s*=`))) {
+        return i + 1;
+      }
+    }
+    return null;
+  }
+
+  // Item field (e.g. ["items", 0, "choices"])
+  if (zodPath[0] === "items" && typeof zodPath[1] === "number") {
+    const itemIndex = zodPath[1];
+    const fieldName = zodPath.length >= 3 && typeof zodPath[2] === "string" ? zodPath[2] : null;
+
+    // Find the Nth [[items]] header
+    let count = -1;
+    let blockStart = -1;
+    let blockEnd = lines.length;
+
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].match(/^\s*\[\[items\]\]/)) {
+        count++;
+        if (count === itemIndex) {
+          blockStart = i;
+        } else if (count === itemIndex + 1) {
+          blockEnd = i;
+          break;
+        }
+      }
+    }
+
+    if (blockStart === -1) return null;
+
+    // If no field name, return the [[items]] header line
+    if (!fieldName) return blockStart + 1;
+
+    // Search for the field within this item block
+    for (let i = blockStart + 1; i < blockEnd; i++) {
+      if (lines[i].match(new RegExp(`^\\s*${escapeRegex(fieldName)}\\s*=`))) {
+        return i + 1;
+      }
+    }
+
+    return null;
+  }
+
+  return null;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function ordinal(n: number): string {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
+/**
+ * Format a single ZodIssue into a human-readable line with TOML context.
+ */
+export function formatZodIssue(issue: ZodIssue, tomlText: string): string {
+  const path = issue.path;
+  const message = issue.message;
+  const lineNumber = resolveTomlLineNumber(tomlText, path);
+  const lineInfo = lineNumber !== null ? ` (line ${lineNumber})` : "";
+
+  // Item field: e.g. ["items", 1, "choices"]
+  if (path[0] === "items" && typeof path[1] === "number" && path.length >= 3) {
+    const fieldName = path[2];
+    const itemOrd = ordinal(path[1] + 1);
+    return `${fieldName} in ${itemOrd} item${lineInfo}: ${message}`;
+  }
+
+  // Top-level field: e.g. ["title"]
+  if (path.length >= 1 && typeof path[0] === "string") {
+    return `${path[0]}${lineInfo}: ${message}`;
+  }
+
+  // Fallback
+  return `${path.join(".")}${lineInfo}: ${message}`;
+}


### PR DESCRIPTION
## Summary
- Changed store error type from `string` to `ZodIssue[]` for structured error handling
- Improved `visible_when` validation to show expected token and position (e.g. `Invalid visible_when: expected value after "=" at position 5: "key1="`)
- Added `resolveTomlLineNumber` utility to map Zod paths to TOML line numbers
- Added `formatZodIssue` formatter showing field name, ordinal item context, and line numbers (e.g. `choices in 2nd item (line 12): Must be an array of unique strings`)
- Updated error display component to render a structured list of errors

## Test plan
- [x] All 22 form-definition tests pass (8 visible-when + 14 error-format)
- [x] ESLint passes with no warnings or errors
- [x] Production build succeeds
- [ ] Manual: enter invalid TOML in editor, verify structured error messages with line numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)